### PR TITLE
Fixes including file multiple times 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 /nbproject/private/
+.idea

--- a/src/Serverfireteam/Blog/BlogServiceProvider.php
+++ b/src/Serverfireteam/Blog/BlogServiceProvider.php
@@ -15,7 +15,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->app->register('Serverfireteam\Panel\PanelServiceProvider');
 
 
-        include __DIR__."/Commands/Command.php";
+        include_once __DIR__."/Commands/Command.php";
         $this->app['blog::install'] = $this->app->share(function()
         {
             return new \Serverfireteam\Blog\Commands\BlogCommand();


### PR DESCRIPTION
Running into this bug:

λ git master\* → php artisan config:cache
Configuration cache cleared!
PHP Fatal error:  Cannot redeclare class Serverfireteam\Blog\Commands\BlogCommand 

Changing this to the proper style of include fixes this bug.
